### PR TITLE
allow to run outside docker

### DIFF
--- a/PlexBot/__init__.py
+++ b/PlexBot/__init__.py
@@ -56,7 +56,7 @@ def load_config(filename: str) -> Dict[str, str]:
     config["plex"]["log_level"] = levels[config["plex"]["log_level"].upper()]
     config["discord"]["log_level"] = levels[config["discord"]["log_level"].upper()]
 
-    if config["lyrics"]["token"].lower() == "none":
-        config["lyrics"]["token"] = None
+    if config["lyrics"] and config["lyrics"]["token"].lower() == "none":
+        config["lyrics"] = None
 
     return config

--- a/PlexBot/__init__.py
+++ b/PlexBot/__init__.py
@@ -1,8 +1,6 @@
 """
 Plex music bot for discord.
 
-Do not import this module, it is intended to be
-used exclusively within a docker environment.
 """
 import logging
 import sys
@@ -19,7 +17,7 @@ plex_log = logging.getLogger("Plex")
 bot_log = logging.getLogger("Bot")
 
 
-def load_config(filename: str) -> Dict[str, str]:
+def load_config(basedir: str,filename: str) -> Dict[str, str]:
     """Loads config from yaml file
 
     Grabs key/value config pairs from a file.
@@ -35,12 +33,12 @@ def load_config(filename: str) -> Dict[str, str]:
     """
     # All config files should be in /config
     # for docker deployment.
-    filename = Path("/config", filename)
+    filename = Path(basedir, filename)
     try:
         with open(filename, "r") as config_file:
             config = yaml.safe_load(config_file)
     except FileNotFoundError:
-        root_log.fatal("Configuration file not found.")
+        root_log.fatal("Configuration file not found at '"+str(filename)+"'.")
         sys.exit(-1)
 
     # Convert str level type to logging constant

--- a/PlexBot/__main__.py
+++ b/PlexBot/__main__.py
@@ -11,7 +11,11 @@ from .bot import General
 from .bot import Plex
 
 # Load config from file
-config = load_config("config.yaml")
+configdir = "config"
+from os import geteuid
+if geteuid() == 0:
+    configdir = "/config"
+config = load_config(configdir,"config.yaml")
 
 BOT_PREFIX = config["discord"]["prefix"]
 TOKEN = config["discord"]["token"]

--- a/PlexBot/__main__.py
+++ b/PlexBot/__main__.py
@@ -20,8 +20,11 @@ BASE_URL = config["plex"]["base_url"]
 PLEX_TOKEN = config["plex"]["token"]
 LIBRARY_NAME = config["plex"]["library_name"]
 
-LYRICS_TOKEN = config["lyrics"]["token"]
-
+if config["lyrics"]:
+    LYRICS_TOKEN = config["lyrics"]["token"]
+else:
+    LYRICS_TOKEN = None
+    
 # Set appropiate log level
 root_log = logging.getLogger()
 plex_log = logging.getLogger("Plex")

--- a/PlexBot/bot.py
+++ b/PlexBot/bot.py
@@ -6,7 +6,6 @@ from urllib.request import urlopen
 import requests
 
 import discord
-import lyricsgenius
 from async_timeout import timeout
 from discord import FFmpegPCMAudio
 from discord.ext import commands
@@ -182,6 +181,7 @@ class Plex(commands.Cog):
         self.bot_prefix = bot.command_prefix
 
         if kwargs["lyrics_token"]:
+            import lyricsgenius
             self.genius = lyricsgenius.Genius(kwargs["lyrics_token"])
         else:
             plex_log.warning("No lyrics token specified, lyrics disabled")


### PR DESCRIPTION
Maybe I'm just a bit old-school, but I like it when apps run standalone as well. In this case, this was fairly easy to accomodate.
This PR contains a few small fixes that provide a bit of debugging convenience for people who don't want to go full docker and/or use only a partial dev stack, namely:
- dependency on `lyricsgenius` is now optional
- lyrics section in the yml config file is now optional 
- `__main__` now checks for the user-ID and only uses the absolute path `/config` if it's the root user, otherwise it uses a relative path `config`
